### PR TITLE
Make progress bar optional (#16)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,6 +105,11 @@ compare both approaches to help you decide:
 .. _debugging harder: https://stackoverflow.com/questions/6970359/find-an-efficient-way-to-integrate-different-language-libraries-into-one-project
 .. _tests: tests/
 
+Options
+-------
+
+To disable a progress bar when loading stemming tables, set environment variable `DISABLE_TQDM=True`.
+
 Development setup
 -----------------
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 from setuptools import find_packages, setup
 
 REQUIRED_PYTHON = [3, 5]
-version = '1.1.0'
+version = '1.2.0'
 
 
 def read(fname):

--- a/stempel/streams.py
+++ b/stempel/streams.py
@@ -17,12 +17,16 @@ limitations under the License.
 
 import struct
 from tqdm import tqdm
+import os
+
+DISABLE_TQDM=os.environ.get("DISABLE_TQDM", False)
+
 
 class ProgressStream:
 
     def __init__(self, stream, total_bytes):
         self.stream = stream
-        self.pbar = tqdm(total=total_bytes, desc='Loading', unit='bytes')
+        self.pbar = tqdm(total=total_bytes, desc='Loading', unit='bytes', disable=DISABLE_TQDM)
 
     def read(self, size):
         self.pbar.update(size)

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -20,7 +20,7 @@ import os
 import time
 
 pwd = os.path.dirname(os.path.abspath(__file__))
-stemmer_table_fpath = os.path.join(pwd, '..', 'data', 'stemmer_20000.tbl')
+stemmer_table_fpath = os.path.join(pwd, '..', 'data', 'original', 'stemmer_20000.tbl')
 jar_fpath = os.path.join(os.getcwd(), 'stempel-8.1.1.jar')
 dict_fpath = os.path.join(pwd, 'sjp_dict.txt')
 


### PR DESCRIPTION
With this change it would be possible to disable tqdm progress bar by setting the environment variable `DISABLE_TQDM=True`.